### PR TITLE
ELB Alerts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+terraform.tfvars
+terraform.tfstate*

--- a/README.md
+++ b/README.md
@@ -29,3 +29,12 @@ Examples of monitored/alerted values include:
   users too slowly
 * Elasticsearch or Kubernetes cluster (including master) `in service instances` is less than `minimum
   instances`. This suggests that there are not enough cluster resources to work properly.
+
+## Issues
+
+* It is not yet possible to enable the group metric collection required on Auto Scaling Groups
+  created by kops. So for now, it should be enabled manually in the EC2 dashboard. Unfortunately
+  KOPS will try to overwrite it if `kops update cluster` is used. See
+  https://github.com/kubernetes/kops/issues/2254
+* Likewise, for now it is not possible to set custom IAM roles on the kops cluster, but there is a
+  pull request that will hopefully solve this soon: https://github.com/kubernetes/kops/pull/2440

--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ Examples of monitored/alerted values include:
 * Elasticsearch or Kubernetes cluster (including master) `in service instances` is less than `minimum
   instances`. This suggests that there are not enough cluster resources to work properly.
 
+There is also support for "legacy" Pelias infrastructure that is still running as individual EC2
+instances behind Elastic Load Balancers, instead of within Kubernetes. By setting appropriate
+Terraform variables, alerts for this infrastructre can be enabled or disabled. All current Pelias
+services (API, pip-service, placeholder, and interpolation are supported individually) Similarly to other
+instances, the only alerts for these instances will be service related:
+
+* ELB healthy instance count is lower than expected
+* ELB latency is high
+* ELB 500 error count is high
+
 ## Issues
 
 * It is not yet possible to enable the group metric collection required on Auto Scaling Groups

--- a/legacy-alerts.tf
+++ b/legacy-alerts.tf
@@ -16,6 +16,7 @@ resource "aws_cloudwatch_metric_alarm" "api-elb-unhealthy-host-alert" {
   insufficient_data_actions = []
 
   actions_enabled = "${var.legacy_alerts_enabled ? 1 : 0}"
+  count = "${var.legacy-pelias-api-elb-name ? 1 : 0}"
   alarm_actions   = ["${data.aws_sns_topic.non-critical-alerts.arn}"]
 
   dimensions {
@@ -36,6 +37,7 @@ resource "aws_cloudwatch_metric_alarm" "api-elb-zero-healthy-host-alert" {
   insufficient_data_actions = []
 
   actions_enabled = "${var.legacy_alerts_enabled ? 1 : 0}"
+  count = "${var.legacy-pelias-api-elb-name ? 1 : 0}"
   alarm_actions   = ["${data.aws_sns_topic.critical-alerts.arn}"]
 
   dimensions {
@@ -57,6 +59,7 @@ resource "aws_cloudwatch_metric_alarm" "pip-elb-unhealthy-host-alert" {
   insufficient_data_actions = []
 
   actions_enabled = "${var.legacy_alerts_enabled ? 1 : 0}"
+  count = "${var.legacy-pelias-pip-elb-name ? 1 : 0}"
   alarm_actions   = ["${data.aws_sns_topic.non-critical-alerts.arn}"]
 
   dimensions {
@@ -77,6 +80,7 @@ resource "aws_cloudwatch_metric_alarm" "pip-elb-zero-healthy-host-alert" {
   insufficient_data_actions = []
 
   actions_enabled = "${var.legacy_alerts_enabled ? 1 : 0}"
+  count = "${var.legacy-pelias-pip-elb-name ? 1 : 0}"
   alarm_actions   = ["${data.aws_sns_topic.critical-alerts.arn}"]
 
   dimensions {
@@ -98,6 +102,7 @@ resource "aws_cloudwatch_metric_alarm" "placeholder-elb-unhealthy-host-alert" {
   insufficient_data_actions = []
 
   actions_enabled = "${var.legacy_alerts_enabled ? 1 : 0}"
+  count = "${var.legacy-pelias-placeholder-elb-name ? 1 : 0}"
   alarm_actions   = ["${data.aws_sns_topic.non-critical-alerts.arn}"]
 
   dimensions {
@@ -118,6 +123,7 @@ resource "aws_cloudwatch_metric_alarm" "placeholder-elb-zero-healthy-host-alert"
   insufficient_data_actions = []
 
   actions_enabled = "${var.legacy_alerts_enabled ? 1 : 0}"
+  count = "${var.legacy-pelias-placeholder-elb-name ? 1 : 0}"
   alarm_actions   = ["${data.aws_sns_topic.critical-alerts.arn}"]
 
   dimensions {
@@ -139,6 +145,7 @@ resource "aws_cloudwatch_metric_alarm" "interpolation-elb-unhealthy-host-alert" 
   insufficient_data_actions = []
 
   actions_enabled = "${var.legacy_alerts_enabled ? 1 : 0}"
+  count = "${var.legacy-pelias-interpolation-elb-name ? 1 : 0}"
   alarm_actions   = ["${data.aws_sns_topic.non-critical-alerts.arn}"]
 
   dimensions {
@@ -159,6 +166,7 @@ resource "aws_cloudwatch_metric_alarm" "interpolation-elb-zero-healthy-host-aler
   insufficient_data_actions = []
 
   actions_enabled = "${var.legacy_alerts_enabled ? 1 : 0}"
+  count = "${var.legacy-pelias-interpolation-elb-name ? 1 : 0}"
   alarm_actions   = ["${data.aws_sns_topic.critical-alerts.arn}"]
 
   dimensions {

--- a/legacy-alerts.tf
+++ b/legacy-alerts.tf
@@ -1,0 +1,167 @@
+# Legacy alerts for Elastic Load Balancers of non-Kubernetes Pelias infrastructure
+
+# the common theme is to have one non-critical alert for any unhealthy hosts, and one critical for
+# zero healthy hosts, for each ELB
+
+resource "aws_cloudwatch_metric_alarm" "api-elb-unhealthy-host-alert" {
+  alarm_name                = "${var.service_name}-${var.environment}-api-elb-unhealthy-host-alert"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "3"
+  metric_name               = "UnHealthyHostCount"
+  namespace                 = "AWS/ELB"
+  period                    = "60"
+  statistic                 = "Maximum"
+  threshold                 = "1"
+  alarm_description         = "This metric monitors the legacy (non-kubernetes) Pelias API ELB for unhealthy hosts. Even one unhealthy host sends a non-critical alert"
+  insufficient_data_actions = []
+
+  actions_enabled = "${var.legacy_alerts_enabled ? 1 : 0}"
+  alarm_actions   = ["${data.aws_sns_topic.non-critical-alerts.arn}"]
+
+  dimensions {
+    LoadBalancerName = "${var.legacy-pelias-api-elb-name}"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "api-elb-zero-healthy-host-alert" {
+  alarm_name                = "${var.service_name}-${var.environment}-api-elb-healthy-host-alert"
+  comparison_operator       = "LessThanOrEqualToThreshold"
+  evaluation_periods        = "3"
+  metric_name               = "HealthyHostCount"
+  namespace                 = "AWS/ELB"
+  period                    = "60"
+  statistic                 = "Minimum"
+  threshold                 = "0"
+  alarm_description         = "This metric monitors the legacy (non-kubernetes) Pelias API ELB for healthy hosts. It sends a critical alert if there are no healthy hosts"
+  insufficient_data_actions = []
+
+  actions_enabled = "${var.legacy_alerts_enabled ? 1 : 0}"
+  alarm_actions   = ["${data.aws_sns_topic.critical-alerts.arn}"]
+
+  dimensions {
+    LoadBalancerName = "${var.legacy-pelias-api-elb-name}"
+  }
+}
+
+# PIP
+resource "aws_cloudwatch_metric_alarm" "pip-elb-unhealthy-host-alert" {
+  alarm_name                = "${var.service_name}-${var.environment}-pip-elb-unhealthy-host-alert"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "3"
+  metric_name               = "UnHealthyHostCount"
+  namespace                 = "AWS/ELB"
+  period                    = "60"
+  statistic                 = "Maximum"
+  threshold                 = "1"
+  alarm_description         = "This metric monitors the legacy (non-kubernetes) Pelias PIP ELB for unhealthy hosts. Even one unhealthy host sends a non-critical alert"
+  insufficient_data_actions = []
+
+  actions_enabled = "${var.legacy_alerts_enabled ? 1 : 0}"
+  alarm_actions   = ["${data.aws_sns_topic.non-critical-alerts.arn}"]
+
+  dimensions {
+    LoadBalancerName = "${var.legacy-pelias-pip-elb-name}"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "pip-elb-zero-healthy-host-alert" {
+  alarm_name                = "${var.service_name}-${var.environment}-pip-elb-healthy-host-alert"
+  comparison_operator       = "LessThanOrEqualToThreshold"
+  evaluation_periods        = "3"
+  metric_name               = "HealthyHostCount"
+  namespace                 = "AWS/ELB"
+  period                    = "60"
+  statistic                 = "Minimum"
+  threshold                 = "0"
+  alarm_description         = "This metric monitors the legacy (non-kubernetes) Pelias PIP ELB for healthy hosts. It sends a critical alert if there are no healthy hosts"
+  insufficient_data_actions = []
+
+  actions_enabled = "${var.legacy_alerts_enabled ? 1 : 0}"
+  alarm_actions   = ["${data.aws_sns_topic.critical-alerts.arn}"]
+
+  dimensions {
+    LoadBalancerName = "${var.legacy-pelias-pip-elb-name}"
+  }
+}
+
+## Placeholder
+resource "aws_cloudwatch_metric_alarm" "placeholder-elb-unhealthy-host-alert" {
+  alarm_name                = "${var.service_name}-${var.environment}-placeholder-elb-unhealthy-host-alert"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "3"
+  metric_name               = "UnHealthyHostCount"
+  namespace                 = "AWS/ELB"
+  period                    = "60"
+  statistic                 = "Maximum"
+  threshold                 = "1"
+  alarm_description         = "This metric monitors the legacy (non-kubernetes) Pelias Placeholder ELB for unhealthy hosts. Even one unhealthy host sends a non-critical alert"
+  insufficient_data_actions = []
+
+  actions_enabled = "${var.legacy_alerts_enabled ? 1 : 0}"
+  alarm_actions   = ["${data.aws_sns_topic.non-critical-alerts.arn}"]
+
+  dimensions {
+    LoadBalancerName = "${var.legacy-pelias-placeholder-elb-name}"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "placeholder-elb-zero-healthy-host-alert" {
+  alarm_name                = "${var.service_name}-${var.environment}-placeholder-elb-healthy-host-alert"
+  comparison_operator       = "LessThanOrEqualToThreshold"
+  evaluation_periods        = "3"
+  metric_name               = "HealthyHostCount"
+  namespace                 = "AWS/ELB"
+  period                    = "60"
+  statistic                 = "Minimum"
+  threshold                 = "0"
+  alarm_description         = "This metric monitors the legacy (non-kubernetes) Pelias Placeholder ELB for healthy hosts. It sends a critical alert if there are no healthy hosts"
+  insufficient_data_actions = []
+
+  actions_enabled = "${var.legacy_alerts_enabled ? 1 : 0}"
+  alarm_actions   = ["${data.aws_sns_topic.critical-alerts.arn}"]
+
+  dimensions {
+    LoadBalancerName = "${var.legacy-pelias-placeholder-elb-name}"
+  }
+}
+
+## Interpolation
+resource "aws_cloudwatch_metric_alarm" "interpolation-elb-unhealthy-host-alert" {
+  alarm_name                = "${var.service_name}-${var.environment}-interpolation-elb-unhealthy-host-alert"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "3"
+  metric_name               = "UnHealthyHostCount"
+  namespace                 = "AWS/ELB"
+  period                    = "60"
+  statistic                 = "Maximum"
+  threshold                 = "1"
+  alarm_description         = "This metric monitors the legacy (non-kubernetes) Pelias interpolation ELB for unhealthy hosts. Even one unhealthy host sends a non-critical alert"
+  insufficient_data_actions = []
+
+  actions_enabled = "${var.legacy_alerts_enabled ? 1 : 0}"
+  alarm_actions   = ["${data.aws_sns_topic.non-critical-alerts.arn}"]
+
+  dimensions {
+    LoadBalancerName = "${var.legacy-pelias-interpolation-elb-name}"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "interpolation-elb-zero-healthy-host-alert" {
+  alarm_name                = "${var.service_name}-${var.environment}-interpolation-elb-healthy-host-alert"
+  comparison_operator       = "LessThanOrEqualToThreshold"
+  evaluation_periods        = "3"
+  metric_name               = "HealthyHostCount"
+  namespace                 = "AWS/ELB"
+  period                    = "60"
+  statistic                 = "Minimum"
+  threshold                 = "0"
+  alarm_description         = "This metric monitors the legacy (non-kubernetes) Pelias Interpolation ELB for healthy hosts. It sends a critical alert if there are no healthy hosts"
+  insufficient_data_actions = []
+
+  actions_enabled = "${var.legacy_alerts_enabled ? 1 : 0}"
+  alarm_actions   = ["${data.aws_sns_topic.critical-alerts.arn}"]
+
+  dimensions {
+    LoadBalancerName = "${var.legacy-pelias-interpolation-elb-name}"
+  }
+}

--- a/legacy-alerts.tf
+++ b/legacy-alerts.tf
@@ -15,8 +15,8 @@ resource "aws_cloudwatch_metric_alarm" "api-elb-unhealthy-host-alert" {
   alarm_description         = "This metric monitors the legacy (non-kubernetes) Pelias API ELB for unhealthy hosts. Even one unhealthy host sends a non-critical alert"
   insufficient_data_actions = []
 
-  actions_enabled = "${var.legacy_alerts_enabled ? 1 : 0}"
-  count = "${var.legacy-pelias-api-elb-name ? 1 : 0}"
+  actions_enabled = "${var.legacy_alerts_enabled  != "" ? 1 : 0}"
+  count           = "${var.legacy-pelias-api-elb-name  != "" ? 1 : 0}"
   alarm_actions   = ["${data.aws_sns_topic.non-critical-alerts.arn}"]
 
   dimensions {
@@ -36,8 +36,8 @@ resource "aws_cloudwatch_metric_alarm" "api-elb-zero-healthy-host-alert" {
   alarm_description         = "This metric monitors the legacy (non-kubernetes) Pelias API ELB for healthy hosts. It sends a critical alert if there are no healthy hosts"
   insufficient_data_actions = []
 
-  actions_enabled = "${var.legacy_alerts_enabled ? 1 : 0}"
-  count = "${var.legacy-pelias-api-elb-name ? 1 : 0}"
+  actions_enabled = "${var.legacy_alerts_enabled  != "" ? 1 : 0}"
+  count           = "${var.legacy-pelias-api-elb-name  != "" ? 1 : 0}"
   alarm_actions   = ["${data.aws_sns_topic.critical-alerts.arn}"]
 
   dimensions {
@@ -58,8 +58,8 @@ resource "aws_cloudwatch_metric_alarm" "pip-elb-unhealthy-host-alert" {
   alarm_description         = "This metric monitors the legacy (non-kubernetes) Pelias PIP ELB for unhealthy hosts. Even one unhealthy host sends a non-critical alert"
   insufficient_data_actions = []
 
-  actions_enabled = "${var.legacy_alerts_enabled ? 1 : 0}"
-  count = "${var.legacy-pelias-pip-elb-name ? 1 : 0}"
+  actions_enabled = "${var.legacy_alerts_enabled  != "" ? 1 : 0}"
+  count           = "${var.legacy-pelias-pip-elb-name  != "" ? 1 : 0}"
   alarm_actions   = ["${data.aws_sns_topic.non-critical-alerts.arn}"]
 
   dimensions {
@@ -79,8 +79,8 @@ resource "aws_cloudwatch_metric_alarm" "pip-elb-zero-healthy-host-alert" {
   alarm_description         = "This metric monitors the legacy (non-kubernetes) Pelias PIP ELB for healthy hosts. It sends a critical alert if there are no healthy hosts"
   insufficient_data_actions = []
 
-  actions_enabled = "${var.legacy_alerts_enabled ? 1 : 0}"
-  count = "${var.legacy-pelias-pip-elb-name ? 1 : 0}"
+  actions_enabled = "${var.legacy_alerts_enabled  != "" ? 1 : 0}"
+  count           = "${var.legacy-pelias-pip-elb-name  != "" ? 1 : 0}"
   alarm_actions   = ["${data.aws_sns_topic.critical-alerts.arn}"]
 
   dimensions {
@@ -101,8 +101,8 @@ resource "aws_cloudwatch_metric_alarm" "placeholder-elb-unhealthy-host-alert" {
   alarm_description         = "This metric monitors the legacy (non-kubernetes) Pelias Placeholder ELB for unhealthy hosts. Even one unhealthy host sends a non-critical alert"
   insufficient_data_actions = []
 
-  actions_enabled = "${var.legacy_alerts_enabled ? 1 : 0}"
-  count = "${var.legacy-pelias-placeholder-elb-name ? 1 : 0}"
+  actions_enabled = "${var.legacy_alerts_enabled  != "" ? 1 : 0}"
+  count           = "${var.legacy-pelias-placeholder-elb-name  != "" ? 1 : 0}"
   alarm_actions   = ["${data.aws_sns_topic.non-critical-alerts.arn}"]
 
   dimensions {
@@ -122,8 +122,8 @@ resource "aws_cloudwatch_metric_alarm" "placeholder-elb-zero-healthy-host-alert"
   alarm_description         = "This metric monitors the legacy (non-kubernetes) Pelias Placeholder ELB for healthy hosts. It sends a critical alert if there are no healthy hosts"
   insufficient_data_actions = []
 
-  actions_enabled = "${var.legacy_alerts_enabled ? 1 : 0}"
-  count = "${var.legacy-pelias-placeholder-elb-name ? 1 : 0}"
+  actions_enabled = "${var.legacy_alerts_enabled  != "" ? 1 : 0}"
+  count           = "${var.legacy-pelias-placeholder-elb-name  != "" ? 1 : 0}"
   alarm_actions   = ["${data.aws_sns_topic.critical-alerts.arn}"]
 
   dimensions {
@@ -144,8 +144,8 @@ resource "aws_cloudwatch_metric_alarm" "interpolation-elb-unhealthy-host-alert" 
   alarm_description         = "This metric monitors the legacy (non-kubernetes) Pelias interpolation ELB for unhealthy hosts. Even one unhealthy host sends a non-critical alert"
   insufficient_data_actions = []
 
-  actions_enabled = "${var.legacy_alerts_enabled ? 1 : 0}"
-  count = "${var.legacy-pelias-interpolation-elb-name ? 1 : 0}"
+  actions_enabled = "${var.legacy_alerts_enabled  != "" ? 1 : 0}"
+  count           = "${var.legacy-pelias-interpolation-elb-name  != "" ? 1 : 0}"
   alarm_actions   = ["${data.aws_sns_topic.non-critical-alerts.arn}"]
 
   dimensions {
@@ -165,8 +165,8 @@ resource "aws_cloudwatch_metric_alarm" "interpolation-elb-zero-healthy-host-aler
   alarm_description         = "This metric monitors the legacy (non-kubernetes) Pelias Interpolation ELB for healthy hosts. It sends a critical alert if there are no healthy hosts"
   insufficient_data_actions = []
 
-  actions_enabled = "${var.legacy_alerts_enabled ? 1 : 0}"
-  count = "${var.legacy-pelias-interpolation-elb-name ? 1 : 0}"
+  actions_enabled = "${var.legacy_alerts_enabled  != "" ? 1 : 0}"
+  count           = "${var.legacy-pelias-interpolation-elb-name  != "" ? 1 : 0}"
   alarm_actions   = ["${data.aws_sns_topic.critical-alerts.arn}"]
 
   dimensions {

--- a/provider.tf
+++ b/provider.tf
@@ -1,0 +1,5 @@
+provider "aws" {
+  region     = "${var.aws_region}"
+  access_key = "${var.aws_access_key}"
+  secret_key = "${var.aws_secret_key}"
+}

--- a/provider.tf
+++ b/provider.tf
@@ -1,5 +1,0 @@
-provider "aws" {
-  region     = "${var.aws_region}"
-  access_key = "${var.aws_access_key}"
-  secret_key = "${var.aws_secret_key}"
-}

--- a/sns.tf
+++ b/sns.tf
@@ -1,0 +1,12 @@
+# this configures data sources for the Amazon SNS topics that send data to pagerduty
+# these data sources are used as the action for other alerts, they aren't modified at all
+
+# data source for alerts that should wake someone up
+data "aws_sns_topic" "critical-alerts" {
+  name = "${var.critical-alert-sns-topic-name}"
+}
+
+# data source for alerts that should not wake someone up
+data "aws_sns_topic" "non-critical-alerts" {
+  name = "${var.non-critical-alert-sns-topic-name}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,11 +1,3 @@
-variable "aws_access_key" {
-  description = "The access key for the terraform user"
-}
-
-variable "aws_secret_key" {
-  description = "The secret key for the terraform user"
-}
-
 variable "aws_region" {
   description = "The AWS region to create things in."
   default     = "us-east-1"

--- a/variables.tf
+++ b/variables.tf
@@ -29,3 +29,27 @@ variable "environment" {
   description = "Which environment (dev, staging, prod, etc) this group of machines is for"
   default     = "dev"
 }
+
+variable "legacy-pelias-api-elb-name" {
+  description = "The full name of the ELB running the legacy Pelias API (not in kubernetes). If blank no alerts for this ELB will be created"
+}
+
+variable "legacy-pelias-placeholder-elb-name" {}
+variable "legacy-pelias-pip-elb-name" {}
+variable "legacy-pelias-interpolation-elb-name" {}
+
+variable "critical-alert-sns-topic-name" {
+  description = "An Amazon SNS topic (for example, a PagerDuty event endpoint) that will be used as the alarm action for CRITICAL alerts"
+}
+
+variable "non-critical-alert-sns-topic-name" {
+  description = "An Amazon SNS topic (for example, a PagerDuty event endpoint) that will be used as the alarm action for non-critical alerts"
+}
+
+variable "alerts_enabled" {
+  default = "true"
+}
+
+variable "legacy_alerts_enabled" {
+  default = "true"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,31 @@
+variable "aws_access_key" {
+  description = "The access key for the terraform user"
+}
+
+variable "aws_secret_key" {
+  description = "The secret key for the terraform user"
+}
+
+variable "aws_region" {
+  description = "The AWS region to create things in."
+  default     = "us-east-1"
+}
+
+variable "availability_zones" {
+  description = "AWS region to launch servers."
+  default     = "us-east-1a,us-east-1b,us-east-1c,us-east-1d,us-east-1e"
+}
+
+variable "aws_vpc_id" {
+  description = "These templates assume a VPC already exists"
+}
+
+variable "service_name" {
+  description = "Used as a prefix for all instances in case you are running several distinct services"
+  default     = "pelias"
+}
+
+variable "environment" {
+  description = "Which environment (dev, staging, prod, etc) this group of machines is for"
+  default     = "dev"
+}


### PR DESCRIPTION
This PR allows CloudWatch Alerts to be created for each of 4 ELBs for our legacy (non-kubernetes) services (API, PIP, placeholder, interpolation). It creates a critical (call) alert for ELBs with zero healthy hosts, and non-critical (email) alerts for ELBs where not all hosts are healthy.