### PR TITLE
Elasticsearch ELB monitoring

### DIFF
--- a/elasticsearch-alerts.tf
+++ b/elasticsearch-alerts.tf
@@ -1,0 +1,15 @@
+# set up alerts on the Elasticsearch ELB
+module "elasticsearch-elb-alerts" {
+  source = "./modules/elb-alerts"
+
+  service_name                      = "${var.service_name}"
+  environment                       = "${var.environment}"
+  actions_enabled                   = "${var.alerts_enabled}"
+  unhealthy-host-evaluation-periods = "${var.unhealthy-host-evaluation-periods}"
+  healthy-host-evaluation-periods   = "${var.healthy-host-evaluation-periods}"
+  critical-alert-sns-topic-arn      = "${data.aws_sns_topic.critical-alerts.arn}"
+  non-critical-alert-sns-topic-arn  = "${data.aws_sns_topic.non-critical-alerts.arn}"
+
+  friendly-lb-name = "Elasticsearch"
+  lb-name          = "${var.pelias-elasticsearch-elb-name}"
+}

--- a/legacy-alerts.tf
+++ b/legacy-alerts.tf
@@ -10,6 +10,7 @@ module "api-elb-alerts" {
   environment                       = "${var.environment}"
   actions_enabled                   = "${var.legacy_alerts_enabled}"
   unhealthy-host-evaluation-periods = "${var.unhealthy-host-evaluation-periods}"
+  healthy-host-evaluation-periods   = "${var.healthy-host-evaluation-periods}"
   critical-alert-sns-topic-arn      = "${data.aws_sns_topic.critical-alerts.arn}"
   non-critical-alert-sns-topic-arn  = "${data.aws_sns_topic.non-critical-alerts.arn}"
 
@@ -24,6 +25,7 @@ module "pip-elb-alerts" {
   environment                       = "${var.environment}"
   actions_enabled                   = "${var.legacy_alerts_enabled}"
   unhealthy-host-evaluation-periods = "${var.unhealthy-host-evaluation-periods}"
+  healthy-host-evaluation-periods   = "${var.healthy-host-evaluation-periods}"
   critical-alert-sns-topic-arn      = "${data.aws_sns_topic.critical-alerts.arn}"
   non-critical-alert-sns-topic-arn  = "${data.aws_sns_topic.non-critical-alerts.arn}"
 
@@ -38,6 +40,7 @@ module "placeholder-elb-alerts" {
   environment                       = "${var.environment}"
   actions_enabled                   = "${var.legacy_alerts_enabled}"
   unhealthy-host-evaluation-periods = "${var.unhealthy-host-evaluation-periods}"
+  healthy-host-evaluation-periods   = "${var.healthy-host-evaluation-periods}"
   critical-alert-sns-topic-arn      = "${data.aws_sns_topic.critical-alerts.arn}"
   non-critical-alert-sns-topic-arn  = "${data.aws_sns_topic.non-critical-alerts.arn}"
 
@@ -52,6 +55,7 @@ module "interpolation-elb-alerts" {
   environment                       = "${var.environment}"
   actions_enabled                   = "${var.legacy_alerts_enabled}"
   unhealthy-host-evaluation-periods = "${var.unhealthy-host-evaluation-periods}"
+  healthy-host-evaluation-periods   = "${var.healthy-host-evaluation-periods}"
   critical-alert-sns-topic-arn      = "${data.aws_sns_topic.critical-alerts.arn}"
   non-critical-alert-sns-topic-arn  = "${data.aws_sns_topic.non-critical-alerts.arn}"
 

--- a/modules/elb-alerts/elb-alerts.tf
+++ b/modules/elb-alerts/elb-alerts.tf
@@ -22,7 +22,7 @@ resource "aws_cloudwatch_metric_alarm" "elb-unhealthy-host-alert" {
 resource "aws_cloudwatch_metric_alarm" "elb-healthy-host-alert" {
   alarm_name                = "${var.service_name}-${var.environment}-${var.friendly-lb-name}-elb-healthy-host-alert"
   comparison_operator       = "LessThanThreshold"
-  evaluation_periods        = "3"
+  evaluation_periods        = "${var.healthy-host-evaluation-periods}"
   metric_name               = "HealthyHostCount"
   namespace                 = "AWS/ELB"
   period                    = "60"

--- a/modules/elb-alerts/elb-alerts.tf
+++ b/modules/elb-alerts/elb-alerts.tf
@@ -19,16 +19,16 @@ resource "aws_cloudwatch_metric_alarm" "elb-unhealthy-host-alert" {
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "api-elb-zero-healthy-host-alert" {
+resource "aws_cloudwatch_metric_alarm" "elb-healthy-host-alert" {
   alarm_name                = "${var.service_name}-${var.environment}-${var.friendly-lb-name}-elb-healthy-host-alert"
-  comparison_operator       = "LessThanOrEqualToThreshold"
+  comparison_operator       = "LessThanThreshold"
   evaluation_periods        = "3"
   metric_name               = "HealthyHostCount"
   namespace                 = "AWS/ELB"
   period                    = "60"
   statistic                 = "Minimum"
-  threshold                 = "0"
-  alarm_description         = "This metric monitors the ${var.friendly-lb-name} ELB for healthy hosts. It sends a critical alert if there are no healthy hosts"
+  threshold                 = "${var.minimum-healthy-hosts}"
+  alarm_description         = "This metric monitors the ${var.friendly-lb-name} ELB for healthy hosts. It sends a critical alert if there are not enough healthy hosts"
   insufficient_data_actions = []
 
   actions_enabled = "${var.actions_enabled  != "" ? 1 : 0}"

--- a/modules/elb-alerts/variables.tf
+++ b/modules/elb-alerts/variables.tf
@@ -29,3 +29,8 @@ variable "unhealthy-host-evaluation-periods" {
   description = "How many periods (which default to minutes) the unhealthy host count alerts for ELBs must be in an unacceptable state for before alerting. This should be set fairly high especailly in dev environments to avoid excessive alerts"
   default     = 10
 }
+
+variable "minimum-healthy-hosts" {
+  description = "The minimum number of healthy hosts required in an ELB. Defaults to 1, but raise to a higher number if more than one is required to consider the service healthy."
+  default     = 1
+}

--- a/modules/elb-alerts/variables.tf
+++ b/modules/elb-alerts/variables.tf
@@ -30,6 +30,11 @@ variable "unhealthy-host-evaluation-periods" {
   default     = 10
 }
 
+variable "healthy-host-evaluation-periods" {
+  description = "How many periods (which default to minutes) the healthy host count alerts for ELBs must be in an unacceptable state for before alerting. This should be set fairly low except perhaps in dev environments, since it represents a complete service failure."
+  default     = 2
+}
+
 variable "minimum-healthy-hosts" {
   description = "The minimum number of healthy hosts required in an ELB. Defaults to 1, but raise to a higher number if more than one is required to consider the service healthy."
   default     = 1

--- a/modules/elb-alerts/variables.tf
+++ b/modules/elb-alerts/variables.tf
@@ -25,10 +25,6 @@ variable "actions_enabled" {
   default     = "true"
 }
 
-variable "legacy_alerts_enabled" {
-  default = "true"
-}
-
 variable "unhealthy-host-evaluation-periods" {
   description = "How many periods (which default to minutes) the unhealthy host count alerts for ELBs must be in an unacceptable state for before alerting. This should be set fairly high especailly in dev environments to avoid excessive alerts"
   default     = 10

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,10 @@ variable "environment" {
   default     = "dev"
 }
 
+variable "pelias-elasticsearch-elb-name" {
+  description = "The full name of the ELB in front of Elasticsearch instances"
+}
+
 variable "legacy-pelias-api-elb-name" {
   description = "The full name of the ELB running the legacy Pelias API (not in kubernetes). If blank no alerts for this ELB will be created"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -50,3 +50,8 @@ variable "unhealthy-host-evaluation-periods" {
   description = "How many periods (which default to minutes) the unhealthy host count alerts for ELBs must be in an unacceptable state for before alerting. This should be set fairly high especailly in dev environments to avoid excessive alerts"
   default     = 10
 }
+
+variable "healthy-host-evaluation-periods" {
+  description = "How many periods (which default to minutes) the healthy host count alerts for ELBs must be in an unacceptable state for before alerting. This should be set fairly low except perhaps in dev environments, since it represents a complete service failure."
+  default     = 2
+}


### PR DESCRIPTION
This PR uses the same sub-module as #2 to allow for creating alerts on Elasticsearch hosts as well. It's really not that different although it would allow us to potentially configure thresholds differently in the future.